### PR TITLE
Alternative to 'get-hash'

### DIFF
--- a/_labs/lab_malware.md
+++ b/_labs/lab_malware.md
@@ -68,13 +68,11 @@ See <a class='alert-link' href='{{'/labs/virtual-machines#using-snapshots' | rel
 
     SHA-256:
 
-    `get-hash ./24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c.exe`
+    `get-filehash ./24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c.exe`
 
     MD5:
 
-    `get-hash -algorithm MD5 ./24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c.exe`
-
-NOTE: If either of these commands do not work, append 'get-hash' to 'get-filehash'
+    `get-filehash -algorithm MD5 ./24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c.exe`
 
 1.  Google the hashes to see what comes up. (You can copy them to the clipboard from a cmd prompt by highlighting them and then right-clicking the highlighted text.)
 1.  Go to [VirusTotal.com](http://VirusTotal.com) and either search for the hash, or upload the `.exe` file. If you do the latter, click the "View last analysis" button. Both approaches should return the same results.

--- a/_labs/lab_malware.md
+++ b/_labs/lab_malware.md
@@ -74,6 +74,7 @@ See <a class='alert-link' href='{{'/labs/virtual-machines#using-snapshots' | rel
 
     `get-hash -algorithm MD5 ./24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c.exe`
 
+NOTE: If either of these commands do not work, append 'get-hash' to 'get-filehash'
 
 1.  Google the hashes to see what comes up. (You can copy them to the clipboard from a cmd prompt by highlighting them and then right-clicking the highlighted text.)
 1.  Go to [VirusTotal.com](http://VirusTotal.com) and either search for the hash, or upload the `.exe` file. If you do the latter, click the "View last analysis" button. Both approaches should return the same results.


### PR DESCRIPTION
'get-hash' did not work in my instance, but get-filehash worked flawlessly.